### PR TITLE
Unpin faraday version

### DIFF
--- a/ruby_odata.gemspec
+++ b/ruby_odata.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency("activesupport", ">= 3.0.0")
   s.add_dependency("excon", "~> 0.45.3")
   s.add_dependency("faraday_middleware")
-  s.add_dependency("faraday", "~> 0.9.1")
+  s.add_dependency("faraday", ">= 0.9.1")
   s.add_dependency("nokogiri", ">= 1.4.2")
 
   s.add_development_dependency("rake", ">= 12.0.0")


### PR DESCRIPTION
Forking [ruby_odata](https://github.com/visoft/ruby_odata) so we don't have faraday version conflicts between our gems.